### PR TITLE
[Port]: ZipArchive DNU `#writeTo:`

### DIFF
--- a/src/Tabular/TabularExport.class.st
+++ b/src/Tabular/TabularExport.class.st
@@ -88,5 +88,7 @@ TabularExport >> workbook: anObject [
 { #category : #'as yet unclassified' }
 TabularExport >> writeZip [
 
-	zip writeToFileNamed: workbook filename
+	workbook filename asFileReference binaryWriteStreamDo: [  :str |
+		zip writeTo: str ]
+	
 ]

--- a/src/Tabular/TabularExportImportTest.class.st
+++ b/src/Tabular/TabularExportImportTest.class.st
@@ -357,22 +357,28 @@ TabularExportImportTest >> testExport8ExportManyWorksheets [
 	| wbk wsheet wbkimported wsheetimported rnd sheetNames cellPositions values |
 	wbk := TabularWorkbook new.
 	rnd := Random new.
-	sheetNames := (1 to: 10) collect: [ :i | 'Sheet ', i printString].
-	values := (1 to: 10) collect: [ :i | i even ifTrue: [rnd nextInt: 1000] ifFalse: [ (rnd nextInt: 100) printStringRadix: 16 ] ].
-	cellPositions := (1 to: 10) collect: [ :i | (rnd nextInt: 5) @ (rnd nextInt: 10) ].
-	1 to: 10 do: [ :i |
+	sheetNames := (1 to: 10) collect: [ :i | 'Sheet ' , i printString ].
+	values := (1 to: 10) collect: [ :i | 
+		          i even
+			          ifTrue: [ rnd nextInteger: 1000 ]
+			          ifFalse: [ (rnd nextInteger: 100) printStringRadix: 16 ] ].
+	cellPositions := (1 to: 10) collect: [ :i | 
+		                 (rnd nextInteger: 5) @ (rnd nextInteger: 10) ].
+	1 to: 10 do: [ :i | 
 		wsheet := TabularWorksheet new.
 		wsheet name: (sheetNames at: i).
 		wsheet at: (cellPositions at: i) putData: (values at: i).
-		wbk addSheet: wsheet].
+		wbk addSheet: wsheet ].
 
 	fname7 ensureDelete.
 	TabularXLSXExport workbook: wbk fileName: fname7.
 
-	wbkimported := XLSXImporter import: fname7 .
- 
-	1 to: 10 do: [ :i |
+	wbkimported := XLSXImporter import: fname7.
+
+	1 to: 10 do: [ :i | 
 		wsheetimported := wbkimported worksheets at: i.
 		self assert: wsheetimported name equals: (sheetNames at: i).
-		self assert: (wsheetimported at: (cellPositions at: i)) data equals: (values at: i)]
+		self
+			assert: (wsheetimported at: (cellPositions at: i)) data
+			equals: (values at: i) ]
 ]

--- a/src/Tabular/TabularWorksheetWriterWordML.class.st
+++ b/src/Tabular/TabularWorksheetWriterWordML.class.st
@@ -244,4 +244,3 @@ TabularWorksheetWriterWordML >> renderWorksheet [
 		ifTrue: [ self renderSheetData ]	
 			"self renderMergeCells"
 ]
-


### PR DESCRIPTION
Not sure which Pharo versions Tabular aims to support. The fix is naive, and assumes only the latest release i.e. P9. A more nuanced fix might be needed if that's not the case, but would probably require a compatibility layer, so might not be worth it unless someone asks for it.

- guessing it was removed prior to P9 release.
- also an deprecation auto-refactor nextInt: -> nextInteger: